### PR TITLE
fix: input no longer goes out of focus after user input, and the react complaint of controlled/uncontrolled inputs

### DIFF
--- a/components/Action/index.js
+++ b/components/Action/index.js
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { uniqueId } from 'lodash'
-
 import { VEX_ACTIONS } from "@utils/constants";
 
 import Spacer from "@components/Spacer";
@@ -149,12 +147,11 @@ const Action = ({ onChangeHandler, index }) => {
             // Filter for all args under contract + function
           ].args.map((arg, i) => {
             return (
-              <React.Fragment key={uniqueId('actions_')}>
+              <React.Fragment key={"arg_"+i}>
                 <Spacer height="20" />
                 <ActionInput
-                  key={uniqueId('select_')}
                   label={arg.name}
-                  value={args[i]}
+                  value={args[i] || ""}
                   type={arg.type}
                   placeholder={arg.placeholder}
                   onChangeHandler={updateArgsAtIndex}
@@ -162,19 +159,17 @@ const Action = ({ onChangeHandler, index }) => {
                 />
               </React.Fragment>
             );
-
           })}
 
           {VEX_ACTIONS[contract.value.key].functions[func.value.key].values.map(
             // Filter for all values under contract + function
             (value, i) => {
               return (
-              <React.Fragment key={uniqueId('actions_interior_')}>
+              <React.Fragment key={"val_"+i}>
                   <Spacer height="20" />
                   <ActionInput
-                    key={i}
                     label={value.name}
-                    value={values[i]}
+                    value={values[i] || ""}
                     type={value.type}
                     placeholder={value.placeholder}
                     onChangeHandler={updateValuesAtIndex}


### PR DESCRIPTION
1. Previously, probably due to the frontend refactoring, the input goes out of focus every time the user enters something. See [here](https://gov.vexchange.io/create) for a demo. After some investigation, I concluded that it is probably due to react creating+rendering a new component every time the input changes. This is caused by the `uniqueId` assigned to each fragment making a new instance every time. The `uniqueId` has since been replaced because react only requires uniqueness among list siblings and not global uniqueness. 
2. React complained about the input being uncontrolled <> controlled. This problem is probably due to a race condition of react not setting the values to `""` fast enough. Added a fix for that as well. Regarding why we did not see this error previously, it is probably due to the new fragment rendering after `updateArgsAndValues` has finished setting the array to the correct size. This is my conjecture, I don't know how to see the exact sequence of events so I can't prove it. 