### PR TITLE
Fix/decimals for uint256

### DIFF
--- a/components/Action/index.js
+++ b/components/Action/index.js
@@ -12,6 +12,7 @@ const Action = ({ onChangeHandler, index }) => {
   const [func, setFunc] = useState(null);
   const [values, setValues] = useState([]);
   const [args, setArgs] = useState([]);
+  const [argDecimals, setArgDecimals] = useState([]);
   const [contract, setContract] = useState(null);
 
   /**
@@ -27,6 +28,7 @@ const Action = ({ onChangeHandler, index }) => {
 
     // Else, nullify arguments and values
     setArgs([]);
+    setArgDecimals([]);
     setValues([]);
   };
 
@@ -40,18 +42,24 @@ const Action = ({ onChangeHandler, index }) => {
 
     // Prefill arrays based on function params
     setArgs(new Array(funcOptions.args.length).fill(""));
+    setArgs(new Array(funcOptions.args.length).fill(""));
     setValues(new Array(funcOptions.values.length).fill(""));
   };
 
   /**
    * Update args array at index
    * @param {String} value to update
+   * @param {Number} decimalPlaces number of decimal places for the value, undefined if not applicable (such as for strings/addresses)
    * @param {Number} index to update at
    */
-  const updateArgsAtIndex = (value, index) => {
+  const updateArgsAtIndex = (value, decimalPlaces, index) => {
     let temp = args;
     temp[index] = value;
     setArgs([...temp]);
+
+    let decimalTemp = argDecimals;
+    decimalTemp[index] = decimalPlaces;
+    setArgDecimals([...decimalTemp]);
   };
 
   /**
@@ -77,6 +85,8 @@ const Action = ({ onChangeHandler, index }) => {
         func ? func.value.signature : null,
         // Args array
         args,
+        // Arg decimals array
+        argDecimals,
         // Values array
         values,
       ],
@@ -99,7 +109,7 @@ const Action = ({ onChangeHandler, index }) => {
   }, [func]);
 
   // Update state of parent container on any change
-  useEffect(updateParentState, [contract, func, args, values]);
+  useEffect(updateParentState, [contract, func, args, argDecimals, values]);
 
   return (
     <Wrapper>
@@ -152,6 +162,7 @@ const Action = ({ onChangeHandler, index }) => {
                 <ActionInput
                   label={arg.name}
                   value={args[i] || ""}
+                  decimalPlaces={arg.decimals}
                   type={arg.type}
                   placeholder={arg.placeholder}
                   onChangeHandler={updateArgsAtIndex}
@@ -175,7 +186,7 @@ const Action = ({ onChangeHandler, index }) => {
                     onChangeHandler={updateValuesAtIndex}
                     onChangeIndex={i}
                   />
-                </React.Fragment>
+              </React.Fragment>
               );
             }
           )}

--- a/components/ActionInput/index.js
+++ b/components/ActionInput/index.js
@@ -7,6 +7,7 @@ const ActionInput = ({
   onChangeIndex,
   placeholder,
   type,
+  decimalPlaces,
 }) => {
   return (
     <Wrapper>
@@ -17,7 +18,7 @@ const ActionInput = ({
         id={label}
         type={type}
         value={value}
-        onChange={(e) => onChangeHandler(e.target.value, onChangeIndex)}
+        onChange={(e) => onChangeHandler(e.target.value, decimalPlaces, onChangeIndex)}
         placeholder={placeholder}
       />
     </Wrapper>

--- a/pages/create.js
+++ b/pages/create.js
@@ -82,7 +82,7 @@ export default function Create() {
       // Assuming proposal creation is successful, route to new proposal
       router.push(`/proposal/${proposalId}`);
     } catch (error) {
-      console.log("Error when creating proposal: " + error);
+      console.error("Error when creating proposal: " + error);
     }
 
   };

--- a/pages/create.js
+++ b/pages/create.js
@@ -19,7 +19,18 @@ import Breadcrumb from "@components/Breadcrumb";
 
 import { PROPOSAL_THRESHOLD } from "@utils/constants";
 
-const defaultActionState = [null, null, [], []];
+const defaultActionState = [
+    // contract address
+    null,
+    // function
+    null,
+    // function arguments array
+    [],
+    // function argument decimals array
+    [],
+    // values array
+    []
+];
 
 export default function Create() {
   const router = useRouter();
@@ -64,6 +75,7 @@ export default function Create() {
         actions.map((action) => action[1]),
         actions.map((action) => action[2]),
         actions.map((action) => action[3]),
+        actions.map((action) => action[4]),
         title,
         description
       );

--- a/pages/proposal/[id].js
+++ b/pages/proposal/[id].js
@@ -372,6 +372,7 @@ const Proposal = ({ id, defaultProposalData }) => {
               const name = collectNameByContract(contract);
               // Collect signature data
               const signatureElements = generateActionSignatureHTML(
+                contract,
                 data.signatures[i],
                 data.calldatas[i]
               );

--- a/pages/proposal/[id].js
+++ b/pages/proposal/[id].js
@@ -40,7 +40,7 @@ const Proposal = ({ id, defaultProposalData }) => {
     getEta,
     collectVotesAtBlock
   } = governance.useContainer();
-  const { address: authed, provider, tick,  unlock } = vechain.useContainer();
+  const { address: authed, tick, unlock } = vechain.useContainer();
 
   // Local state
   const [data, setData] = useState(JSON.parse(defaultProposalData));
@@ -65,7 +65,7 @@ const Proposal = ({ id, defaultProposalData }) => {
   }
 
   const refreshVotesAndState = async () => {
-    if (tick && provider && governanceContract)
+    if (tick && governanceContract)
     {
       const proposalsABI = find(GovernorAlphaABI, {name: 'proposals'});
       const proposalsMethod = governanceContract.method(proposalsABI);
@@ -86,7 +86,7 @@ const Proposal = ({ id, defaultProposalData }) => {
       })
     }
   }
-  
+
   const fetchVotes = async () => {
     if (authed && data) {
       const votes = await collectVotesAtBlock(data.startBlock);
@@ -172,7 +172,7 @@ const Proposal = ({ id, defaultProposalData }) => {
             actions.disabled = true;
             actions.tooltipText = `You had insufficient votes when the proposal was created.`
           }
-        }   
+        }
         // Receipt and votes still loading
         else {
           actions.text = "Loading";
@@ -287,7 +287,7 @@ const Proposal = ({ id, defaultProposalData }) => {
     }
   };
 
-  useEffect(refreshVotesAndState, [tick, provider, governanceContract]);
+  useEffect(refreshVotesAndState, [tick, governanceContract]);
   useEffect(fetchETAForQueued, [proposals]);
   useEffect(fetchReceipt, [authed, data]);
   useEffect(fetchVotes, [authed, data])

--- a/state/governance.js
+++ b/state/governance.js
@@ -342,9 +342,6 @@ function useGovernance() {
       typeof values[i] !== "undefined" ? [...target, ...values[i]] : [...target]
     );
 
-    console.log(calldataRaw);
-    console.log(argDecimals);
-
     // Convert stringified calldata to bytes
     const calldataBytes = await Promise.all(
       functions.map(
@@ -354,7 +351,6 @@ function useGovernance() {
       )
     );
 
-    console.log(calldataBytes);
     // Create a new proposal
     const proposeABI = find(GovernorAlphaABI, { name: "propose" });
     const proposeMethod = governanceContract.method(proposeABI);

--- a/state/governance.js
+++ b/state/governance.js
@@ -254,9 +254,10 @@ function useGovernance() {
    * Generates padded bytes based on type and value
    * @param {String} type solidity type
    * @param {String} value matching to solidity type
+   * @param {Number} decimalPlaces number of decimal places (if applicable)
    * @returns {String} emulating ethers.Bytes
    */
-  const generateBytesByType = async (type, value) => {
+  const generateBytesByType = async (type, value, decimalPlaces) => {
     switch (type) {
       // If type of value is address:
       case "address":
@@ -267,12 +268,16 @@ function useGovernance() {
 
         // Pad address for 20 bytes and drop 0x
         return ethers.utils.hexZeroPad(value, 32).substring(2);
+
       // Else if, type of value is uint256
       case "uint256":
+        // assume decimal places to be 0 if unspecified in VEX_ACTIONS
+        if (decimalPlaces === undefined) { decimalPlaces = 0; }
+
         // Format value with appropriate decimals
         const valueDecimals = ethers.utils.parseUnits(
-          Number(value).toFixed(18),
-          18
+          Number(value).toFixed(decimalPlaces),
+          decimalPlaces
         );
         // Convert BigNumber to HexString
         const valueHex = valueDecimals.toHexString();
@@ -285,9 +290,10 @@ function useGovernance() {
    * Generates bytes per function
    * @param {String} signature of function
    * @param {String[]} values of function params
+   * @param {Number[]} decimals of values
    * @returns {String} emulating ethers.Bytes
    */
-  const generateBytes = async (signature, values) => {
+  const generateBytes = async (signature, values, decimals) => {
     // Collect types array from signature
     const typesString = signature.split("(").pop().split(")")[0];
     const typesArray = typesString.split(",");
@@ -297,7 +303,7 @@ function useGovernance() {
       typesArray.map(
         async (type, i) =>
           // Generate bytes by type
-          await generateBytesByType(type, values[i])
+          await generateBytesByType(type, values[i], decimals[i])
       )
     );
 
@@ -310,6 +316,7 @@ function useGovernance() {
    * @param {String[]} contracts array of target addresses
    * @param {String[]} functions array of function signatures to be called
    * @param {String[]} funcArgs array of function arguments to fill
+   * @param {Number[]} argDecimals array of decimals for integer function arguments
    * @param {String[]} values array of function param values to fill
    * @param {String} title of proposal
    * @param {String} description of proposal
@@ -319,6 +326,7 @@ function useGovernance() {
     contracts,
     functions,
     funcArgs,
+    argDecimals,
     values,
     title,
     description
@@ -333,14 +341,20 @@ function useGovernance() {
       // By zipping target and values arrays if they exist
       typeof values[i] !== "undefined" ? [...target, ...values[i]] : [...target]
     );
+
+    console.log(calldataRaw);
+    console.log(argDecimals);
+
     // Convert stringified calldata to bytes
     const calldataBytes = await Promise.all(
       functions.map(
         async (func, i) =>
           // By generating bytes for each individual function signature and param values
-          await generateBytes(func, calldataRaw[i])
+          await generateBytes(func, calldataRaw[i], argDecimals[i])
       )
     );
+
+    console.log(calldataBytes);
     // Create a new proposal
     const proposeABI = find(GovernorAlphaABI, { name: "propose" });
     const proposeMethod = governanceContract.method(proposeABI);
@@ -391,7 +405,8 @@ function useGovernance() {
         isLoading: false,
         autoClose: 5000
       });
-    } else {
+    }
+    else {
       toast.update(toastID, {
         render: <ErrorToast />,
         type: "error",

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,4 +1,6 @@
 import { ethers } from "ethers";
+import { find } from "lodash";
+import { getAddress } from "ethers/lib/utils";
 
 // Declare constants by network
 const VEX_CONSTANTS = {
@@ -19,7 +21,7 @@ const VEX_CONSTANTS = {
     },
     factory: {
       name: "VexchangeV2Factory",
-      address: "0xb312582c023cc4938cf0faea2fd609b46d7509a2"
+      address: "0xB312582C023Cc4938CF0faEA2fd609b46D7509A2"
     },
     router: {
       name: "Router",
@@ -51,11 +53,11 @@ const VEX_CONSTANTS = {
     },
     factory: {
       name: "VexchangeV2Factory",
-      address: "0xd15a91ee3f57313a6129a4a58c73fcbdad34c23c"
+      address: "0xD15A91EE3f57313A6129A4a58c73fcBDAd34c23c"
     },
     router: {
       name: "Router",
-      address: "0x01d6b50b31c18d7f81ede43935cadf79901b0ea0"
+      address: "0x01d6B50b31C18D7f81EDe43935caDF79901B0ea0"
     },
     wvet: {
       name: "Wrapped VET",
@@ -334,20 +336,28 @@ const collectNameByContract = (contract) => {
 
 /**
  * Parses hexstring based on function signature types for appropriate params
+ * @param {String} contractAddress address of the contract
  * @param {String} signature function signature
  * @param {String} bytes HexString
  * @returns {Object[String[], String[]]} Two arrays, one for types and one for parsed params
  */
-const generateActionBySignatureBytes = (signature, bytes) => {
+const generateActionBySignatureBytes = (contractAddress, signature, bytes) => {
   // Collect types array from signature
   const typesString = signature.split("(").pop().split(")")[0];
   const typesArray = typesString.split(",");
+
+  // Use checksum address
+  const contract = find(VEX_ACTIONS, { address: getAddress(contractAddress) });
+  const func = find(contract.functions, { signature: signature });
+  const args = func.args;
 
   // Setup bytes hexstring (removing 0x prefix)
   let tempBytes = bytes.substring(2);
 
   // Setup array to hold parsed params
   let parsedParams = [];
+
+  let argsIndex = 0;
 
   // For each type of typesArray
   for (const type of typesArray) {
@@ -378,12 +388,13 @@ const generateActionBySignatureBytes = (signature, bytes) => {
         tempBytes = tempBytes.substring(64, tempBytes.length);
 
         // Parse uint256 as decimal value
-        const decimalUint256 = ethers.utils.formatUnits(parsedUint256, 18);
+        const decimalUint256 = ethers.utils.formatUnits(parsedUint256, args[argsIndex].decimals);
 
         // Updated parsedParams array
         parsedParams.push(decimalUint256);
         break;
     }
+    ++argsIndex;
   }
 
   // Return array of function types and parsed params
@@ -392,13 +403,14 @@ const generateActionBySignatureBytes = (signature, bytes) => {
 
 /**
  * Uses generateActionBySignatureBytes to return renderable HTML for actions
+ * @param {String} contractName name of the contract
  * @param {String} signature function signature
  * @param {String} bytes HexString
  * @returns {HTMLElement[]} array of elements ot render
  */
-const generateActionSignatureHTML = (signature, bytes) => {
+const generateActionSignatureHTML = (contractName, signature, bytes) => {
   // Collect parsed params
-  const { parsed } = generateActionBySignatureBytes(signature, bytes);
+  const { parsed } = generateActionBySignatureBytes(contractName, signature, bytes);
   // Generate signature name
   const signatureName = signature.split("(")[0];
 
@@ -421,7 +433,8 @@ const generateActionSignatureHTML = (signature, bytes) => {
           {param}
         </a>
       );
-    } else {
+    }
+    else {
       // Else, span
       elements.push(<span>{param}</span>);
     }

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -97,6 +97,7 @@ const VEX_ACTIONS = [
             name: "amount",
             placeholder: "value",
             type: "number",
+            decimals: 18
           },
         ],
         values: [],
@@ -113,7 +114,8 @@ const VEX_ACTIONS = [
           {
             name: "amount",
             placeholder: "amount",
-            type: "number"
+            type: "number",
+            decimals: 18
           }
         ],
         values: [],
@@ -130,7 +132,8 @@ const VEX_ACTIONS = [
           {
             name: "amount",
             placeholder: "amount",
-            type: "number"
+            type: "number",
+            decimals: 18
           }
         ],
         values: []
@@ -142,7 +145,8 @@ const VEX_ACTIONS = [
           {
             name: "rawAmount",
             placeholder: "amount",
-            type: "number"
+            type: "number",
+            decimals: 18
           }
         ],
         values: []
@@ -184,7 +188,8 @@ const VEX_ACTIONS = [
           {
             name: "Delay",
             placeholder: "time in seconds. Minimum 2 days (172800), maximum 30 days (2592000)",
-            type: "number"
+            type: "number",
+            decimals: 0
           }
         ],
         values: [],
@@ -214,7 +219,8 @@ const VEX_ACTIONS = [
           {
             name: "swapFee",
             placeholder: "basis points",
-            type: "number"
+            type: "number",
+            decimals: 0
           }
         ],
         values: []
@@ -226,7 +232,8 @@ const VEX_ACTIONS = [
           {
             name: "platformFee",
             placeholder: "basis points",
-            type: "number"
+            type: "number",
+            decimals: 0
           }
         ],
         values: []
@@ -255,7 +262,8 @@ const VEX_ACTIONS = [
           {
             name: "swapFee",
             placeholder: "basis points",
-            type: "number"
+            type: "number",
+            decimals: 0
           }
         ],
         values: []
@@ -272,7 +280,8 @@ const VEX_ACTIONS = [
           {
             name: "platformFee",
             placeholder: "basis points",
-            type: "number"
+            type: "number",
+            decimals: 0
           }
         ],
         values: []
@@ -296,91 +305,6 @@ const VEX_ACTIONS = [
       }
     ]
   },
-  {
-    contract: "Router",
-    address: VEX_NETWORK.router.address,
-    functions: [
-      {
-        name: "Remove liquidity",
-        signature: "removeLiquidity(address,address,uint256,uint256,uint256,address,uint256)",
-        args: [
-          {
-            name: "tokenA",
-            placeholder: "address",
-            type: "text"
-          },
-          {
-            name: "tokenB",
-            placeholder: "address",
-            type: "text"
-          },
-          {
-            name: "liquidity",
-            placeholder: "number of LP tokens",
-            type: "number"
-          },
-          {
-            name: "amountAMin",
-            placeholder: "Amount A minimum",
-            type: "number"
-          },
-          {
-            name: "amountBMin",
-            placeholder: "Amount B minimum",
-            type: "number"
-          },
-          {
-            name: "to",
-            placeholder: "address",
-            type: "text"
-          },
-          {
-            name: "deadline",
-            placeholder: "timestamp",
-            type: "number"
-          }
-        ],
-        values: []
-      },
-      {
-        name: "Remove liquidity VET",
-        signature: "removeLiquidity(address,uint256,uint256,uint256,address,uint256)",
-        args: [
-          {
-            name: "token",
-            placeholder: "address",
-            type: "text"
-          },
-          {
-            name: "liquidity",
-            placeholder: "number of LP tokens",
-            type: "number"
-          },
-          {
-            name: "amountTokenMin",
-            placeholder: "Token Amount Minimum",
-            type: "number"
-          },
-          {
-            name: "amountVetMin",
-            placeholder: "Amount of VET minimum",
-            type: "number"
-          },
-          {
-            name: "to",
-            placeholder: "address",
-            type: "text"
-          },
-          {
-            name: "deadline",
-            placeholder: "timestamp",
-            type: "number"
-          }
-        ],
-        values: []
-      }
-    ]
-  }
 ];
 
 /**


### PR DESCRIPTION
# Why?
- In the original fish.vote code base, it assumed that all uint256 numbers were 18 decimal based. This is incompatible for our uses as some uint256 uses do not have decimals 
- This will result in the first proposal failing to execute, as the `swapFee` is a non-sensical large number
- I was supposed to catch this during dev and testing but failed to do so


# What changed?
- refactored the parsing of numbers during proposal creation, to generate the correct numerical value 
- refactored the parsing of numbers during proposal viewing, to show the corresponding human readable number  

After this PR is merged into prod, we can re-submit the proposal. 
